### PR TITLE
feat: add a route to get some data on moderation

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -467,10 +467,12 @@ def get_data(n_days: int = 31):
     """Get number of tickets by status for the last n days.
 
     Args:
-        n_days (int): The number of days from which to fetch ticket data. Default is 7 days.
+        n_days (int): The number of days from which to fetch ticket data.
+        Default is 7 days.
 
     Returns:
-        dict: A dictionary containing the number of tickets for each status (e.g., 'open', 'closed').
+        dict: A dictionary containing the number of tickets for each status
+        (e.g., 'open', 'closed').
     """
     with db:
         # Return the total number of tickets
@@ -480,22 +482,25 @@ def get_data(n_days: int = 31):
         start_date = datetime.utcnow() - timedelta(days=n_days)
         # Query for getting the count of tickets by status in the last n days
         tickets = (
-            TicketModel
-            .select(TicketModel.status, fn.COUNT(TicketModel.id).alias('count'))
+            TicketModel.select(
+                TicketModel.status, fn.COUNT(TicketModel.id).alias("count")
+            )
             .where(TicketModel.created_at >= start_date)
             .group_by(TicketModel.status)
         )
         # Idem group by flavor
         tickets_by_flavor = (
-            TicketModel
-            .select(TicketModel.flavor, fn.COUNT(TicketModel.id).alias('count'))
+            TicketModel.select(
+                TicketModel.flavor, fn.COUNT(TicketModel.id).alias("count")
+            )
             .where(TicketModel.created_at >= start_date)
             .group_by(TicketModel.flavor)
         )
         # Idem group by type
         tickets_by_type = (
-            TicketModel
-            .select(TicketModel.type, fn.COUNT(TicketModel.id).alias('count'))
+            TicketModel.select(
+                TicketModel.type, fn.COUNT(TicketModel.id).alias("count")
+            )
             .where(TicketModel.created_at >= start_date)
             .group_by(TicketModel.type)
         )
@@ -504,7 +509,9 @@ def get_data(n_days: int = 31):
     result = {
         "total_tickets": total_tickets,
         "tickets_by_status": {ticket.status: ticket.count for ticket in tickets},
-        "tickets_by_flavor": {ticket.flavor: ticket.count for ticket in tickets_by_flavor},
+        "tickets_by_flavor": {
+            ticket.flavor: ticket.count for ticket in tickets_by_flavor
+        },
         "tickets_by_type": {ticket.type: ticket.count for ticket in tickets_by_type},
         "n_days": n_days,
         "start_date": start_date.isoformat(),

--- a/app/api.py
+++ b/app/api.py
@@ -477,7 +477,7 @@ def update_ticket_status(
 
 
 @api_v1_router.get("/stats")
-def getStats(
+def get_stats(
     n_days: int = 31,
     _: Any = Depends(get_auth_dependency(UserStatus.isModerator)),
 ) -> dict:

--- a/app/api.py
+++ b/app/api.py
@@ -488,8 +488,19 @@ def get_data(
         Default is 31 days.
 
     Returns:
-        dict: A dictionary containing the number of tickets for each status
-        (e.g., 'open', 'closed').
+        dict: A dictionary containing the total number of tickets,
+        tickets by status, tickets by flavor, and tickets by type.
+        The keys are:
+            - total_tickets: Total number of tickets.
+            - tickets_by_status: A dictionary with ticket status as keys    
+                and the count of tickets as values.
+            - tickets_by_flavor: A dictionary with ticket flavor as keys
+                and the count of tickets as values.
+            - tickets_by_type: A dictionary with ticket type as keys
+                and the count of tickets as values.
+            - n_days: The number of days for which the data is fetched.
+            - start_date: The start date of the data range in ISO format.
+            - end_date: The end date of the data range in ISO format.
     """
     with db:
         # Return the total number of tickets

--- a/app/api.py
+++ b/app/api.py
@@ -477,7 +477,7 @@ def update_ticket_status(
 
 
 @api_v1_router.get("/stats")
-def get_data(
+def getStats(
     n_days: int = 31,
     _: Any = Depends(get_auth_dependency(UserStatus.isModerator)),
 ) -> dict:

--- a/app/api.py
+++ b/app/api.py
@@ -485,11 +485,27 @@ def get_data(n_days: int = 31):
             .where(TicketModel.created_at >= start_date)
             .group_by(TicketModel.status)
         )
+        # Idem group by flavor
+        tickets_by_flavor = (
+            TicketModel
+            .select(TicketModel.flavor, fn.COUNT(TicketModel.id).alias('count'))
+            .where(TicketModel.created_at >= start_date)
+            .group_by(TicketModel.flavor)
+        )
+        # Idem group by type
+        tickets_by_type = (
+            TicketModel
+            .select(TicketModel.type, fn.COUNT(TicketModel.id).alias('count'))
+            .where(TicketModel.created_at >= start_date)
+            .group_by(TicketModel.type)
+        )
 
     # Prepare the results
     result = {
         "total_tickets": total_tickets,
-        "tickets": {ticket.status: ticket.count for ticket in tickets},
+        "tickets_by_status": {ticket.status: ticket.count for ticket in tickets},
+        "tickets_by_flavor": {ticket.flavor: ticket.count for ticket in tickets_by_flavor},
+        "tickets_by_type": {ticket.type: ticket.count for ticket in tickets_by_type},
         "n_days": n_days,
         "start_date": start_date.isoformat(),
         "end_date": datetime.utcnow().isoformat(),

--- a/app/api.py
+++ b/app/api.py
@@ -492,7 +492,7 @@ def get_data(
         tickets by status, tickets by flavor, and tickets by type.
         The keys are:
             - total_tickets: Total number of tickets.
-            - tickets_by_status: A dictionary with ticket status as keys    
+            - tickets_by_status: A dictionary with ticket status as keys
                 and the count of tickets as values.
             - tickets_by_flavor: A dictionary with ticket flavor as keys
                 and the count of tickets as values.


### PR DESCRIPTION
### What
Missing datas about the Nutripatrol Tool, this PR add a routes to get some data about tickets

- Number of tickets grouped by status for the last N days
- Total number of tickets

### Screenshot
<img width="1064" alt="Capture d’écran 2025-04-30 à 10 55 35" src="https://github.com/user-attachments/assets/4350f534-29e0-4c66-bc9b-edd03d69333e" />


### Fixes bug(s)
Fixes #95 
From nutripatrol front-end repo no73
