### PR TITLE
fix: Robotoff auth by bearer token

### DIFF
--- a/.env
+++ b/.env
@@ -37,4 +37,4 @@ CORS_ALLOW_ORIGINS=["http://localhost:5173"]
 # AUTH_SERVER_STATIC=https://world.openfoodfacts.org
 
 # Local auth token for Robotoff, used for local dev
-AUTH_BEARER_TOKEN_ROBOTOFF=0b3c1f2d-4e6a-4f8b-9c5d-7e8f9a0b1c2d
+AUTH_BEARER_TOKEN_ROBOTOFF=local-dev-token

--- a/.env
+++ b/.env
@@ -35,3 +35,6 @@ CORS_ALLOW_ORIGINS=["http://localhost:5173"]
 
 # Used for local dev, in production must be empty
 # AUTH_SERVER_STATIC=https://world.openfoodfacts.org
+
+# Local auth token for Robotoff, used for local dev
+AUTH_BEARER_TOKEN_ROBOTOFF=0b3c1f2d-4e6a-4f8b-9c5d-7e8f9a0b1c2d

--- a/.github/workflows/container-deploy.yml
+++ b/.github/workflows/container-deploy.yml
@@ -125,6 +125,7 @@ jobs:
           echo "POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}" >> .env
           # Expose PostgreSQL locally on port 5434
           echo "POSTGRES_EXPOSE=127.0.0.1:5434" >> .env
+          echo "AUTH_BEARER_TOKEN_ROBOTOFF=${{ secrets.AUTH_BEARER_TOKEN_ROBOTOFF }}" >> .env
 
     - name: Create Docker volumes
       uses: appleboy/ssh-action@master

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -64,6 +64,22 @@ def get_auth_dependency(user_status: UserStatus):
 
 
 async def auth_dependency(request: Request, user_status: UserStatus):
+    # Check for bearer token in Authorization header
+    # Currently, this is only for robotoff
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.startswith("Bearer "):
+        # Check if hashed token matches the env variable
+        token = auth_header.split(" ")[1]
+        hashed_token = hashlib.sha256(token.encode()).hexdigest()
+        hashed_env_token = hashlib.sha256(
+            os.getenv("AUTH_BEARER_TOKEN_ROBOTOFF").encode()
+        ).hexdigest()
+        if hashed_token != hashed_env_token:
+            raise HTTPException(status_code=403, detail="Invalid bearer token")
+        return  # If the token is valid, we just return
+
+    # If no bearer token is provided, we check for session cookie
+    # Check for session cookie
     session_cookie = request.cookies.get("session")
     auth_base_url = get_auth_server(request) + "/cgi/auth.pl"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ x-api-common: &api-common
     - CORS_ALLOW_ORIGINS
     - OFF_TLD
     - AUTH_SERVER_STATIC
+    - AUTH_BEARER_TOKEN_ROBOTOFF
   networks:
     - default
 


### PR DESCRIPTION
### What
Previous auth feature broke robotoff connection
This PR enable connection with robotoff with a bearer token

### Fixes bug(s)
[#158](https://github.com/openfoodfacts/nutripatrol-frontend/issues/158)

