### PR TITLE
fix: add missing args to urlunparse func

### DIFF
--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -45,6 +45,11 @@ def get_auth_server(request: Request):
         (
             "https",  # Use 'https' scheme, as auth server is always secure
             new_netloc,
+            "",
+            "",  # No path
+            "",  # No query
+            "",  # No query
+            "",  # No fragment
         )
     )
 


### PR DESCRIPTION
### What
Add missing args for url unparse func
