### PR TITLE
fix: Potential fix for code scanning alert no. 2: Failure to use secure cookies

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -574,7 +574,13 @@ if auth_server_static and auth_server_static != "":
         Then, call this endpoint with the session cookie in the body.
         """
         response = PlainTextResponse("Session cookie set")
-        response.set_cookie(key="session", value=body.session)
+        response.set_cookie(
+            key="session",
+            value=body.session,
+            secure=True,
+            httponly=True,
+            samesite="Strict"
+        )
         return response
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfoodfacts/nutripatrol/security/code-scanning/2](https://github.com/openfoodfacts/nutripatrol/security/code-scanning/2)

To fix the problem, update the call to `response.set_cookie` on line 577 to explicitly set the `secure`, `httponly`, and `samesite` attributes. The recommended values are `secure=True`, `httponly=True`, and `samesite="Strict"` (or `"Lax"` if you want to allow some cross-site usage, but `"Strict"` is safest). This change should be made directly in the `set_session_cookie` function in `app/api.py`. No additional imports or definitions are required, as these are standard parameters for the `set_cookie` method in FastAPI/Starlette.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
