### PR TITLE
fix: support listing tickets without filters

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -396,7 +396,7 @@ def get_tickets(
 ) -> GetTicketsResponse:
     """Get all tickets.
 
-    This function is used to get all tickets with status open.
+    This function is used to get all tickets, optionally filtered by status.
     """
     with db:
         offset = (page - 1) * page_size
@@ -413,17 +413,18 @@ def get_tickets(
                 FlagModel.reason.in_(reason)
             )
             where_clause.append(TicketModel.id.in_(subquery))
+        query = TicketModel.select()
+        if where_clause:
+            query = query.where(*where_clause)
 
         # Get the total number of tickets with the specified filters
-        count = TicketModel.select().where(*where_clause).count()
+        count = query.count()
         max_page = count // page_size + int(count % page_size != 0)
         if page > max_page:
             return GetTicketsResponse(tickets=[], max_page=max_page)
         return GetTicketsResponse(
             tickets=list(
-                TicketModel.select()
-                .where(*where_clause)
-                .order_by(TicketModel.created_at.desc())
+                query.order_by(TicketModel.created_at.desc())
                 .offset(offset)
                 .limit(page_size)
                 .dicts()

--- a/tests/unit/test_tickets.py
+++ b/tests/unit/test_tickets.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta
+
+import pytest
+from peewee import SqliteDatabase
+
+import app.api as api
+from app.api import IssueType, TicketStatus, get_tickets
+from app.models import FlagModel, ModeratorActionModel, TicketModel
+
+MODELS = [TicketModel, FlagModel, ModeratorActionModel]
+
+
+@pytest.fixture()
+def test_db(monkeypatch):
+    database = SqliteDatabase(":memory:")
+    monkeypatch.setattr(api, "db", database)
+    with database.bind_ctx(MODELS):
+        database.create_tables(MODELS)
+        yield database
+        database.drop_tables(MODELS)
+
+
+def _create_ticket(
+    barcode: str,
+    status: TicketStatus,
+    created_at: datetime,
+):
+    return TicketModel.create(
+        barcode=barcode,
+        type=IssueType.product,
+        url=f"https://world.openfoodfacts.org/product/{barcode}",
+        status=status,
+        image_id=None,
+        flavor="off",
+        created_at=created_at,
+    )
+
+
+def test_get_tickets_without_filters_returns_all_ticket_statuses(test_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    _create_ticket("111", TicketStatus.open, now)
+    _create_ticket("222", TicketStatus.closed, now + timedelta(minutes=1))
+
+    response = get_tickets(_=None)
+
+    assert response.max_page == 1
+    assert [ticket.barcode for ticket in response.tickets] == ["222", "111"]
+    assert [ticket.status for ticket in response.tickets] == [
+        TicketStatus.closed,
+        TicketStatus.open,
+    ]
+
+
+def test_get_tickets_with_status_filter_still_filters_results(test_db):
+    now = datetime(2026, 1, 1, 12, 0, 0)
+    _create_ticket("111", TicketStatus.open, now)
+    _create_ticket("222", TicketStatus.closed, now + timedelta(minutes=1))
+
+    response = get_tickets(status=TicketStatus.open, _=None)
+
+    assert response.max_page == 1
+    assert [ticket.barcode for ticket in response.tickets] == ["111"]
+    assert [ticket.status for ticket in response.tickets] == [TicketStatus.open]
+
+
+def test_get_tickets_without_filters_returns_empty_page_when_no_tickets(test_db):
+    response = get_tickets(_=None)
+
+    assert response.max_page == 0
+    assert response.tickets == []


### PR DESCRIPTION
## Summary
- Fix GET /api/v1/tickets when it is called without query filters.
- Reuse a base Peewee query for both counting and paginated ticket retrieval, only applying .where() when filters are present.
- Update the endpoint docstring so the generated API docs no longer say that the unfiltered endpoint only returns open tickets.
- Add regression coverage for unfiltered ticket listing, existing status=open filtering, and the empty-result case.

## Root Cause
When no query parameters were provided, where_clause stayed empty. The endpoint then called TicketModel.select().where(*where_clause), which makes Peewee try to reduce an empty expression list and raises TypeError: reduce() of empty iterable with no initial value.

This change keeps the existing filter behavior when filters are provided, while allowing the no-filter path preferred in #131 to return both open and closed tickets.

## Testing
- pytest -q
- lack --check app tests
- isort --check-only app tests
- lake8 app tests
- Manual Postgres smoke test: migrated a local Postgres container, seeded one open ticket and one closed ticket, verified the no-status call returns both tickets and status=open still returns only the open ticket.

Note: pre-commit run --all-files could not execute as a wrapper on my VPS because the hooks request python3.11 and the VPS currently has Python 3.12. I ran the configured Black, isort, and flake8 versions directly instead.

*This PR was developed by Codex with supervision from jmtdev0.*
