### PR TITLE
fix: permissions for top issues

### DIFF
--- a/.github/workflows/top-issues.yml
+++ b/.github/workflows/top-issues.yml
@@ -2,6 +2,9 @@ name: Top issues action.
 on:
   schedule:
   - cron:  '0 0 */1 * *'
+permissions:
+  contents: read
+  issues: write
 jobs:
   ShowAndLabelTopIssues:
     name: Display and label top issues.


### PR DESCRIPTION
fix: permissions for top issues

- `contents: read` (read repo metadata/content)
- `issues: write` (label/update issues)

