### PR TITLE
fix: permissions for merge conflict autolabel

### DIFF
--- a/.github/workflows/merge-conflict-autolabel.yml
+++ b/.github/workflows/merge-conflict-autolabel.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
fix: permissions for merge conflict autolabel
- `contents: read` (safe baseline for checkout/metadata access),
- `pull-requests: write` (needed to update PR labels),
- `issues: write` (labels are issue objects in GitHub’s model, and PR labeling may require this scope).
