### PR TITLE
fix: permissions for semantic PRs action

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,5 +1,9 @@
 name: "Semantic PRs"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   pull_request_target:
     types:


### PR DESCRIPTION
fix: permissions for semantic PRs action

- `contents: read` (read repository content/metadata)
- `pull-requests: read` (read PR metadata/title)
